### PR TITLE
Migrate plugin to use dry-struct from virtus

### DIFF
--- a/lib/maven/tools/model.rb
+++ b/lib/maven/tools/model.rb
@@ -1,4 +1,6 @@
-require 'virtus'
+require 'dry-types'
+require 'dry-struct'
+require 'dry/struct/with_setters'
 
 # keep things in line with java collections
 class Array
@@ -6,372 +8,285 @@ class Array
     delete( *args )
   end
 end
-    
+
+module Types
+  include Dry.Types()
+end
+
 module Maven
   module Tools
-    Base = Virtus.model
-
-    module GAV
-      def self.included( base )
-        base.attribute :group_id, String
-        base.attribute :artifact_id, String
-        base.attribute :version, String
-      end
-    end
-    module GA
-      def self.included( base )
-        base.attribute :group_id, String
-        base.attribute :artifact_id, String
-      end
-    end
-    module SU
-      def self.included( base )
-        base.attribute :system, String
-        base.attribute :url, String
-      end
-    end
-    module NU
-      def self.included( base )
-        base.attribute :name, String
-        base.attribute :url, String
-      end
-    end
-    module INU
-      def self.included( base )
-        base.attribute :id, String
-        base.attribute :name, String
-        base.attribute :url, String
-      end
+    class Base < Dry::Struct::WithSetters
+      transform_keys(&:to_sym)
     end
 
-    class Parent
-      include Base
-
-      include GAV
-
-      attribute :relative_path, String
+    class GAV < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
     end
-    class Organization
-      include Base
-
-      include NU
+    class GA < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
     end
-    class License
-      include Base
-
-      include NU
-      attribute :distribution, String
-      attribute :comments, String
+    class SU < Base
+      attribute? :system, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class Developer
-      include Base
-
-      include INU
-      attribute :email, String
-      attribute :organization, String
-      attribute :organization_url, String
-      attribute :roles, String
-      attribute :timezone, String
-      attribute :properties, Hash
+    class NU < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class Contributor
-      include Base
-
-      include NU
-      attribute :email, String
-      attribute :organization, String
-      attribute :organization_url, String
-      attribute :roles, String
-      attribute :timezone, String
-      attribute :properties, Hash
+    class INU < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class MailingList
-      include Base
 
-      attribute :name, String
-      attribute :subscribe, String
-      attribute :unsubscribe, String
-      attribute :post, String
-      attribute :archive, String
-      attribute :other_archives, Array[ String ]
+    class Parent < GAV
+      attribute? :relative_path, Types::Coercible::String.optional
+    end
+    class Organization < NU; end
+    class License < NU
+      attribute? :distribution, Types::Coercible::String.optional
+      attribute? :comments, Types::Coercible::String.optional
+    end
+    class Developer < INU
+      attribute? :email, Types::Coercible::String.optional
+      attribute? :organization, Types::Coercible::String.optional
+      attribute? :organization_url, Types::Coercible::String.optional
+      attribute? :roles, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :timezone, Types::Coercible::String.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+    end
+    class Contributor < NU
+      attribute? :email, Types::Coercible::String.optional
+      attribute? :organization, Types::Coercible::String.optional
+      attribute? :organization_url, Types::Coercible::String.optional
+      attribute? :roles, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :timezone, Types::Coercible::String.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+    end
+    class MailingList < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :subscribe, Types::Coercible::String.optional
+      attribute? :unsubscribe, Types::Coercible::String.optional
+      attribute? :post, Types::Coercible::String.optional
+      attribute? :archive, Types::Coercible::String.optional
+      attribute? :other_archives, Types::Array.of(Types::Coercible::String).default { Array.new }
 
       def archives=( archives )
         self.archive = archives.shift
         self.other_archives = archives
       end
     end
-    class Prerequisites
-      include Base
-
-      attribute :maven, String
+    class Prerequisites < Base
+      attribute? :maven, Types::Coercible::String.optional
     end
-    class Scm
-      include Base
-
-      attribute :connection, String
-      attribute :developer_connection, String
-      attribute :tag, String
-      attribute :url, String
+    class Scm < Base
+      attribute? :connection, Types::Coercible::String.optional
+      attribute? :developer_connection, Types::Coercible::String.optional
+      attribute? :tag, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
     end
-    class IssueManagement
-      include Base
-
-      include SU
+    class IssueManagement < SU
     end
-    class Notifier
-      include Base
-      
-      attribute :type, String
-      attribute :send_on_error, Boolean
-      attribute :send_on_failure, Boolean
-      attribute :send_on_success, Boolean
-      attribute :send_on_warning, Boolean
-      attribute :address, String
-      attribute :configuration, Hash
+    class Notifier < Base
+      attribute? :type, Types::Coercible::String.optional
+      attribute? :send_on_error, Types::Params::Bool
+      attribute? :send_on_failure, Types::Params::Bool
+      attribute? :send_on_success, Types::Params::Bool
+      attribute? :send_on_warning, Types::Params::Bool
+      attribute? :address, Types::Coercible::String.optional
+      attribute? :configuration, Types::Hash.default { Hash.new }
     end
-    class CiManagement
-      include Base
-
-      include SU
-      
-      attribute :notifiers, Array[ Notifier ]
+    class CiManagement < SU
+      attribute? :notifiers, Types::Array.of( Notifier ).default { Array.new }
     end
-    class Site
-      include Base
-
-      include INU
+    class Site < INU
     end
-    class Relocation
-      include Base
-
-      include GAV
-      attribute :message, String
+    class Relocation < GAV
+      attribute? :message, Types::Coercible::String.optional
     end
-    class RepositoryPolicy
-      include Base
-
-      attribute :enabled, Boolean
-      attribute :update_policy, String
-      attribute :checksum_policy, String
+    class RepositoryPolicy < Base
+      attribute? :enabled, Types::Params::Bool
+      attribute? :update_policy, Types::Coercible::String.optional
+      attribute? :checksum_policy, Types::Coercible::String.optional
     end
-    class Repository
-      include Base
-
-      attribute :releases, RepositoryPolicy
-      attribute :snapshots, RepositoryPolicy
-
-      include INU
-
-      attribute :layout, String
+    class Repository < INU
+      attribute? :releases, RepositoryPolicy.optional
+      attribute? :snapshots, RepositoryPolicy.optional
+      attribute? :layout, Types::Coercible::String.optional
     end
     class PluginRepository < Repository; end
     class DeploymentRepository < Repository; end
-    class DistributionManagement
-      include Base
-
-      attribute :repository, Repository
-      attribute :snapshot_repository, Repository
-      attribute :site, Site
-      attribute :download_url, String
-      attribute :status, String
-      attribute :relocation, Relocation
+    class DistributionManagement < Base
+      attribute? :repository, Repository.optional
+      attribute? :snapshot_repository, Repository.optional
+      attribute? :site, Site.optional
+      attribute? :download_url, Types::Coercible::String.optional
+      attribute? :status, Types::Coercible::String.optional
+      attribute? :relocation, Relocation.optional
     end
-    class Exclusion
-      include Base
-
-      include GA
-    end
-    class Dependency
-      include Base
-
-      include GAV
-
-      attribute :type, String
-      attribute :classifier, String
-      attribute :scope, String
-      attribute :system_path, String
-      attribute :exclusions, Array[ Exclusion ]
-      attribute :optional, Boolean
+    class Exclusion < GA; end
+    class Dependency < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
+      attribute? :type, Types::Coercible::String.optional
+      attribute? :classifier, Types::Coercible::String.optional
+      attribute? :scope, Types::Coercible::String.optional
+      attribute? :system_path, Types::Coercible::String.optional
+      attribute? :exclusions, Types::Array.of( Exclusion ).default { Array.new }
+      attribute? :optional, Types::Params::Bool
 
       # silent default
       def type=( t )
         if t.to_sym == :jar
-          @type = nil
+          @attributes['type']  = nil
         else
-          @type = t
+          @attributes['type']  = t
         end
       end
     end
-    class DependencyManagement
-      include Base
-
-      attribute :dependencies, Array[ Dependency ]
+    class DependencyManagement < Base
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
     end
-    class Extension
-      include Base
-
-      include GAV
+    class Extension < GAV; end
+    class Resource < Base
+      attribute? :target_path, Types::Coercible::String.optional
+      attribute? :filtering, Types::Coercible::String.optional
+      attribute? :directory, Types::Coercible::String.optional
+      attribute? :includes, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :excludes, Types::Array.of(Types::Coercible::String).default { Array.new }
     end
-    class Resource
-      include Base
-
-      attribute :target_path, String
-      attribute :filtering, String
-      attribute :directory, String
-      attribute :includes, Array[ String ]
-      attribute :excludes, Array[ String ]
+    class Execution < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :phase, Types::Coercible::String.optional
+      attribute? :goals, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :inherited, Types::Params::Bool
+      attribute? :configuration, Types::Hash.default { Hash.new }
     end
-    class Execution
-      include Base
-
-      attribute :id, String
-      attribute :phase, String
-      attribute :goals, Array[ String ]
-      attribute :inherited, Boolean
-      attribute :configuration, Hash
-    end
-    class Plugin
-      include Base
-
-      include GAV
-      attribute :extensions, Boolean
-      attribute :executions, Array[ Execution ]
-      attribute :dependencies, Array[ Dependency ]
-      attribute :goals, Array[ String ]
-      attribute :inherited, Boolean
-      attribute :configuration, Hash
+    class Plugin < Base
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
+      attribute? :extensions, Types::Params::Bool
+      attribute? :executions, Types::Array.of( Execution ).default { Array.new }
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
+      attribute? :goals, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :inherited, Types::Params::Bool
+      attribute? :configuration, Types::Hash.default { Hash.new }
 
       # silent default
       def group_id=( v )
         if v.to_s == 'org.apache.maven.plugins'
-          @group_id = nil
+          @attributes['group_id'] = nil
         else
-          @group_id = v
+          @attributes['group_id'] = v
         end
       end
     end
-    class PluginManagement
-      include Base
-
-      attribute :plugins, Array[ Plugin ]
+    class PluginManagement < Base
+      attribute? :plugins, Types::Array.of( Plugin ).default { Array.new }
     end
-    class ReportSet
-      include Base
-
-      attribute :id, String
-      attribute :reports, Array[ String ]
-      attribute :inherited, Boolean
-      attribute :configuration, Hash
+    class ReportSet < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :reports, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :inherited, Types::Params::Bool
+      attribute? :configuration, Types::Hash.default { Hash.new }
     end
-    class ReportPlugin
-      include Base
-
-      include GAV
-
-      attribute :report_sets, Array[ ReportSet ]
+    class ReportPlugin < GAV
+      attribute? :report_sets, Types::Array.of( ReportSet ).default { Array.new }
     end
-    class Reporting
-      include Base
-
-      attribute :exclude_defaults, Boolean
-      attribute :output_directory, String
-      attribute :plugins, Array[ ReportPlugin ]
+    class Reporting < Base
+      attribute? :exclude_defaults, Types::Params::Bool
+      attribute? :output_directory, Types::Coercible::String.optional
+      attribute? :plugins, Types::Array.of( ReportPlugin ).default { Array.new }
     end
-    class Build
-      include Base
-
-      attribute :source_directory, String
-      attribute :script_source_directory, String
-      attribute :test_source_directory, String
-      attribute :output_directory, String
-      attribute :test_output_directory, String
-      attribute :extensions, Array[ Extension ]
-      attribute :default_goal, String
-      attribute :resources, Array[ Resource ]
-      attribute :test_resources, Array[ Resource ]
-      attribute :directory, String
-      attribute :final_name, String
-      attribute :filters, Array[ String ]
-      attribute :plugin_management, PluginManagement
-      attribute :plugins, Array[ Plugin ]
+    class Build < Base
+      attribute? :source_directory, Types::Coercible::String.optional
+      attribute? :script_source_directory, Types::Coercible::String.optional
+      attribute? :test_source_directory, Types::Coercible::String.optional
+      attribute? :output_directory, Types::Coercible::String.optional
+      attribute? :test_output_directory, Types::Coercible::String.optional
+      attribute? :extensions, Types::Array.of( Extension ).default { Array.new }
+      attribute? :default_goal, Types::Coercible::String.optional
+      attribute? :resources, Types::Array.of( Resource ).default { Array.new }
+      attribute? :test_resources, Types::Array.of(  Resource  ).default { Array.new }
+      attribute? :directory, Types::Coercible::String.optional
+      attribute? :final_name, Types::Coercible::String.optional
+      attribute? :filters, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :plugin_management, PluginManagement.optional
+      attribute? :plugins, Types::Array.of( Plugin ).default { Array.new }
     end
-    class ActivationOS
-      include Base
-
-      attribute :name, String
-      attribute :family, String
-      attribute :arch, String
-      attribute :version, String
+    class ActivationOS < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :family, Types::Coercible::String.optional
+      attribute? :arch, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
     end
-    class ActivationProperty
-      include Base
-
-      attribute :name, String
-      attribute :value, String
+    class ActivationProperty < Base
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :value, Types::Coercible::String.optional
     end
-    class ActivationFile
-      include Base
-
-      attribute :missing, String
-      attribute :exists, String
+    class ActivationFile < Base
+      attribute? :missing, Types::Coercible::String.optional
+      attribute? :exists, Types::Coercible::String.optional
     end
-    class Activation
-      include Base
-
-      attribute :active_by_default, Boolean
-      attribute :jdk, String
-      attribute :os, ActivationOS
-      attribute :property, ActivationProperty
-      attribute :file, ActivationFile
+    class Activation < Base
+      attribute? :active_by_default, Types::Params::Bool
+      attribute? :jdk, Types::Coercible::String.optional
+      attribute? :os, ActivationOS.optional
+      attribute? :property, ActivationProperty.optional
+      attribute? :file, ActivationFile.optional
     end
-    class Profile
-      include Base
-
-      attribute :id, String
-      attribute :activation, Activation
-      attribute :build, Build
-      attribute :modules, Array[ String ]
-      attribute :distribution_management, DistributionManagement
-      attribute :properties, Hash
-      attribute :dependency_management, DependencyManagement
-      attribute :dependencies, Array[ Dependency ]
-      attribute :repositories, Array[ Repository ]
-      attribute :plugin_repositories, Array[ PluginRepository ]
-      attribute :reporting, Reporting
+    class Profile < Base
+      attribute? :id, Types::Coercible::String.optional
+      attribute? :activation, Activation.optional
+      attribute? :build, Build.optional
+      attribute? :modules, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :distribution_management, DistributionManagement.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+      attribute? :dependency_management, DependencyManagement.optional
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
+      attribute? :repositories, Types::Array.of( Repository ).default { Array.new }
+      attribute? :plugin_repositories, Types::Array.of( PluginRepository ).default { Array.new }
+      attribute? :reporting, Reporting.optional
     end
-    class Model
-      include Base
+    class Model < Base
+      attribute? :model_version, Types::Coercible::String.optional
+      attribute? :parent, Parent.optional
 
-      attribute :model_version, String
-      attribute :parent, Parent
+      attribute? :group_id, Types::Coercible::String.optional
+      attribute? :artifact_id, Types::Coercible::String.optional
+      attribute? :version, Types::Coercible::String.optional
 
-      include GAV
+      attribute? :packaging, Types::Coercible::String.optional
 
-      attribute :packaging, String
+      attribute? :name, Types::Coercible::String.optional
+      attribute? :url, Types::Coercible::String.optional
 
-      include NU
-
-      attribute :description, String
-      attribute :inception_year, String
-      attribute :organization, Organization
-      attribute :licenses, Array[ License ]
-      attribute :developers, Array[ Developer ]
-      attribute :contributors, Array[ Contributor ]
-      attribute :mailing_lists, Array[ MailingList ]
-      attribute :prerequisites, Prerequisites
-      attribute :modules, Array[ String ]
-      attribute :scm, Scm
-      attribute :issue_management, IssueManagement
-      attribute :ci_management, CiManagement
-      attribute :distribution_management, DistributionManagement
-      attribute :properties, Hash
-      attribute :dependency_management, DependencyManagement
-      attribute :dependencies, Array[ Dependency ]
-      attribute :repositories, Array[ Repository ]
-      attribute :plugin_repositories, Array[ PluginRepository ]
-      attribute :build, Build
-      attribute :reporting, Reporting
-      attribute :profiles, Array[ Profile ]
+      attribute? :description, Types::Coercible::String.optional
+      attribute? :inception_year, Types::Coercible::String.optional
+      attribute? :organization, Organization.optional
+      attribute? :licenses, Types::Array.of( License ).default { Array.new }
+      attribute? :developers, Types::Array.of( Developer ).default { Array.new }
+      attribute? :contributors, Types::Array.of( Contributor ).default { Array.new }
+      attribute? :mailing_lists, Types::Array.of( MailingList ).default { Array.new }
+      attribute? :prerequisites, Prerequisites.optional
+      attribute? :modules, Types::Array.of(Types::Coercible::String).default { Array.new }
+      attribute? :scm, Scm.optional
+      attribute? :issue_management, IssueManagement.optional
+      attribute? :ci_management, CiManagement.optional
+      attribute? :distribution_management, DistributionManagement.optional
+      attribute? :properties, Types::Hash.default { Hash.new }
+      attribute? :dependency_management, DependencyManagement.optional
+      attribute? :dependencies, Types::Array.of( Dependency ).default { Array.new }
+      attribute? :repositories, Types::Array.of( Repository ).default { Array.new }
+      attribute? :plugin_repositories, Types::Array.of( PluginRepository ).default { Array.new }
+      attribute? :build, Build.optional
+      attribute? :reporting, Reporting.optional
+      attribute? :profiles, Types::Array.of( Profile ).default { Array.new }
     end
   end
 end

--- a/lib/maven/tools/version.rb
+++ b/lib/maven/tools/version.rb
@@ -20,6 +20,6 @@
 #
 module Maven
   module Tools
-    VERSION = '1.1.7'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/lib/maven/tools/visitor.rb
+++ b/lib/maven/tools/visitor.rb
@@ -65,7 +65,7 @@ module Maven
           buffer.push( buffer.empty? ? e : e.capitalize )
         end.join
       end
-      
+
       def accept_project( project )
         accept( 'project', project )
         @io.close if @io.respond_to? :close
@@ -144,7 +144,7 @@ module Maven
           end_tag( name )
         end
       end
-      
+
       def escape_value( value )
         value = value.to_s.dup
         value.gsub!( /&/, '&amp;' )

--- a/maven-tools.gemspec
+++ b/maven-tools.gemspec
@@ -28,7 +28,14 @@ Gem::Specification.new do |s|
   s.test_files += Dir['spec/**/*gemspec']
   s.test_files += Dir['spec/**/*gem']
 
-  s.add_runtime_dependency 'virtus', '~> 1.0'
+  s.add_runtime_dependency 'dry-container', '~> 0.7.2'
+  s.add_runtime_dependency 'dry-configurable', '~> 0.12.1'
+  s.add_runtime_dependency 'dry-core', '~> 0.6.0'
+  s.add_runtime_dependency 'dry-inflector', '~> 0.2.0'
+  s.add_runtime_dependency 'dry-types', '~> 1.5.1'
+  s.add_runtime_dependency 'dry-struct', '~> 1.4.0'
+  s.add_runtime_dependency 'dry-struct-setters', '~> 0.4.0'
+
 
 # get them out from here until jruby-maven-plugin installs test gems somewhere else then runtime gems
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,7 @@
 <project>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>1.1.6</version>
-  <packaging>gem</packaging>
-  <name>helpers for maven related tasks</name>
   <url>http://github.com/torquebox/maven-tools</url>
   <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+
   <developers>
     <developer>
       <name>Christian Meier</name>
@@ -19,17 +14,8 @@
   </scm>
   <repositories>
     <repository>
-      <id>rubygems</id>
-      <name>Rubygems Proxy</name>
-      <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
+      <id>mavengems</id>
+      <url>mavengem:https://rubygems.org</url>
     </repository>
   </repositories>
   <properties>
@@ -39,31 +25,73 @@
   <dependencies>
     <dependency>
       <groupId>rubygems</groupId>
-      <artifactId>virtus</artifactId>
-      <version>[1.0,1.99999]</version>
+      <artifactId>dry-container</artifactId>
+      <version>0.7.2</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-configurable</artifactId>
+      <version>0.12.1</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-core</artifactId>
+      <version>0.6.0</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-inflector</artifactId>
+      <version>0.2.0</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-types</artifactId>
+      <version>1.5.1</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct</artifactId>
+      <version>1.4.0</version>
+      <type>gem</type>
+    </dependency>
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>dry-struct-setters</artifactId>
+      <version>0.4.0</version>
       <type>gem</type>
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>rake</artifactId>
-      <version>[10.0,10.99999]</version>
+      <version>10.5.0</version>
       <type>gem</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>rubygems</groupId>
       <artifactId>minitest</artifactId>
-      <version>[5.3,5.99999]</version>
+      <version>5.15.0</version>
       <type>gem</type>
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <modelVersion>4.0.0</modelVersion>
+  <name>helpers for maven related tasks</name>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>1.2.0</version>
+  <packaging>gem</packaging>
   <build>
     <extensions>
       <extension>
-        <groupId>de.saumya.mojo</groupId>
-        <artifactId>gem-extension</artifactId>
-        <version>${jruby.plugins.version}</version>
+        <groupId>org.torquebox.mojo</groupId>
+        <artifactId>mavengem-wagon</artifactId>
+        <version>1.0.3</version>
       </extension>
     </extensions>
     <directory>${basedir}/pkg</directory>
@@ -72,6 +100,7 @@
         <groupId>de.saumya.mojo</groupId>
         <artifactId>gem-maven-plugin</artifactId>
         <version>${jruby.plugins.version}</version>
+        <extensions>true</extensions>
         <configuration>
           <gemspec>maven-tools.gemspec</gemspec>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,12 @@
 <project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>1.2.0</version>
+  <packaging>gem</packaging>
+  <name>helpers for maven related tasks</name>
   <url>http://github.com/torquebox/maven-tools</url>
   <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
-
   <developers>
     <developer>
       <name>Christian Meier</name>
@@ -80,12 +85,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <modelVersion>4.0.0</modelVersion>
-  <name>helpers for maven related tasks</name>
-  <groupId>rubygems</groupId>
-  <artifactId>maven-tools</artifactId>
-  <version>1.2.0</version>
-  <packaging>gem</packaging>
   <build>
     <extensions>
       <extension>

--- a/spec/artifact_spec.rb
+++ b/spec/artifact_spec.rb
@@ -4,67 +4,67 @@ require 'maven/tools/artifact'
 describe Maven::Tools::Artifact do
 
   it 'should convert from coordinate' do
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123' ).to_s.must_equal 'sdas:das:jar:tes:123'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123' ).to_s.must_equal 'sdas:das:jar:123'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]' ).to_s.must_equal 'sdas:das:jar:tes:[123,234]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]' ).to_s.must_equal 'sdas:das:jar:[123,234]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:tes:123:[de:fr,gb:us]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:123:[de:fr,gb:us]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]'
-    Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]:[de:fr,gb:us]' ).to_s.must_equal 'sdas:das:jar:[123,234]:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123' ).to_s).must_equal 'sdas:das:jar:tes:123'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123' ).to_s).must_equal 'sdas:das:jar:123'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]' ).to_s).must_equal 'sdas:das:jar:tes:[123,234]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]' ).to_s).must_equal 'sdas:das:jar:[123,234]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:123:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:tes:123:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:123:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:123:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:tes:[123,234]:[de:fr,gb:us]'
+    _(Maven::Tools::Artifact.from_coordinate( 'sdas:das:jar:[123,234]:[de:fr,gb:us]' ).to_s).must_equal 'sdas:das:jar:[123,234]:[de:fr,gb:us]'
   end
 
   it 'should setup artifact' do
-    Maven::Tools::Artifact.new( "sdas", "das", "jar", "123", "tes" ).to_s.must_equal 'sdas:das:jar:tes:123'
-    Maven::Tools::Artifact.new( "sdas", "das", "jar", "123" ).to_s.must_equal 'sdas:das:jar:123'
-    Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", ["fds:fre"] ).to_s.must_equal 'sdas.asd:das:jar:123:[fds:fre]'
-    Maven::Tools::Artifact.new( "sdas.asd", "das", "jar","123",  "bla", ["fds:fre", "ferf:de"] ).to_s.must_equal 'sdas.asd:das:jar:bla:123:[fds:fre,ferf:de]'
-    Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", "blub", ["fds:fre", "ferf:de"] ).to_s.must_equal 'sdas.asd:das:jar:blub:123:[fds:fre,ferf:de]'
+    _(Maven::Tools::Artifact.new( "sdas", "das", "jar", "123", "tes" ).to_s).must_equal 'sdas:das:jar:tes:123'
+    _(Maven::Tools::Artifact.new( "sdas", "das", "jar", "123" ).to_s).must_equal 'sdas:das:jar:123'
+    _(Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", ["fds:fre"] ).to_s).must_equal 'sdas.asd:das:jar:123:[fds:fre]'
+    _(Maven::Tools::Artifact.new( "sdas.asd", "das", "jar","123",  "bla", ["fds:fre", "ferf:de"] ).to_s).must_equal 'sdas.asd:das:jar:bla:123:[fds:fre,ferf:de]'
+    _(Maven::Tools::Artifact.new( "sdas.asd", "das", "jar", "123", "blub", ["fds:fre", "ferf:de"] ).to_s).must_equal 'sdas.asd:das:jar:blub:123:[fds:fre,ferf:de]'
   end
 
   it 'should convert ruby version contraints - gems' do
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '=1' ).to_s.must_equal 'rubygems:asd:gem:[1,1.0.0.0.0.1)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>=1' ).to_s.must_equal 'rubygems:asd:gem:[1,)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=1' ).to_s.must_equal 'rubygems:asd:gem:[0,1]'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>1' ).to_s.must_equal 'rubygems:asd:gem:(1,)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<1' ).to_s.must_equal 'rubygems:asd:gem:[0,1)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '!=1' ).to_s.must_equal 'rubygems:asd:gem:(1,)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>1' ).to_s.must_equal 'rubygems:asd:gem:(1,2)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>1' ).to_s.must_equal 'rubygems:asd:gem:(1,2]'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>=1' ).to_s.must_equal 'rubygems:asd:gem:[1,2)'
-    Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>=1' ).to_s.must_equal 'rubygems:asd:gem:[1,2]'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '=1' ).to_s).must_equal 'rubygems:asd:gem:[1,1.0.0.0.0.1)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>=1' ).to_s).must_equal 'rubygems:asd:gem:[1,)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=1' ).to_s).must_equal 'rubygems:asd:gem:[0,1]'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '>1' ).to_s).must_equal 'rubygems:asd:gem:(1,)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<1' ).to_s).must_equal 'rubygems:asd:gem:[0,1)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '!=1' ).to_s).must_equal 'rubygems:asd:gem:(1,)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>1' ).to_s).must_equal 'rubygems:asd:gem:(1,2)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>1' ).to_s).must_equal 'rubygems:asd:gem:(1,2]'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<2', '>=1' ).to_s).must_equal 'rubygems:asd:gem:[1,2)'
+    _(Maven::Tools::Artifact.from( :gem, 'rubygems:asd', '<=2', '>=1' ).to_s).must_equal 'rubygems:asd:gem:[1,2]'
   end
 
   it 'should convert ruby version contraints - jars' do
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '=1' ).to_s.must_equal 'org.something:asd:jar:[1,1.0.0.0.0.1)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>=1' ).to_s.must_equal 'org.something:asd:jar:[1,)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=1' ).to_s.must_equal 'org.something:asd:jar:[0,1]'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>1' ).to_s.must_equal 'org.something:asd:jar:(1,)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<1' ).to_s.must_equal 'org.something:asd:jar:[0,1)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '!=1' ).to_s.must_equal 'org.something:asd:jar:(1,)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>1' ).to_s.must_equal 'org.something:asd:jar:(1,2)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>1' ).to_s.must_equal 'org.something:asd:jar:(1,2]'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>=1' ).to_s.must_equal 'org.something:asd:jar:[1,2)'
-    Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>=1' ).to_s.must_equal 'org.something:asd:jar:[1,2]'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '=1' ).to_s).must_equal 'org.something:asd:jar:[1,1.0.0.0.0.1)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>=1' ).to_s).must_equal 'org.something:asd:jar:[1,)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=1' ).to_s).must_equal 'org.something:asd:jar:[0,1]'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '>1' ).to_s).must_equal 'org.something:asd:jar:(1,)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<1' ).to_s).must_equal 'org.something:asd:jar:[0,1)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '!=1' ).to_s).must_equal 'org.something:asd:jar:(1,)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>1' ).to_s).must_equal 'org.something:asd:jar:(1,2)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>1' ).to_s).must_equal 'org.something:asd:jar:(1,2]'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<2', '>=1' ).to_s).must_equal 'org.something:asd:jar:[1,2)'
+    _(Maven::Tools::Artifact.from( :jar, 'org.something:asd', '<=2', '>=1' ).to_s).must_equal 'org.something:asd:jar:[1,2]'
   end  
 
   it 'passes in scope to artifact' do
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1' )
-    a.to_s.must_equal 'org.something:asd:jar:1'
+    _(a.to_s).must_equal 'org.something:asd:jar:1'
     a[ :scope ].must_be_nil
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1', :scope => :provided )
-    a.to_s.must_equal 'org.something:asd:jar:1'
-    a[ :scope ].must_equal :provided
+    _(a.to_s).must_equal 'org.something:asd:jar:1'
+    _(a[ :scope ]).must_equal :provided
   end
   it 'passes in exclusions to artifact' do
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1' )
-    a.to_s.must_equal 'org.something:asd:jar:1'
+    _(a.to_s).must_equal 'org.something:asd:jar:1'
     a[ :exclusions ].must_be_nil
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1', :exclusions => ["org.something:dsa"] )
-    a.to_s.must_equal 'org.something:asd:jar:1:[org.something:dsa]'
-    a[ :exclusions ].must_equal [ 'org.something:dsa' ]
+    _(a.to_s).must_equal 'org.something:asd:jar:1:[org.something:dsa]'
+    _(a[ :exclusions ]).must_equal [ 'org.something:dsa' ]
     a = Maven::Tools::Artifact.from( :jar, 'org.something:asd', '1', :exclusions => ["org.something:dsa", "org.anything:qwe"] )
-    a.to_s.must_equal 'org.something:asd:jar:1:[org.something:dsa,org.anything:qwe]'
-    a[ :exclusions ].must_equal [ 'org.something:dsa', 'org.anything:qwe' ]
+    _(a.to_s).must_equal 'org.something:asd:jar:1:[org.something:dsa,org.anything:qwe]'
+    _(a[ :exclusions ]).must_equal [ 'org.something:dsa', 'org.anything:qwe' ]
   end
 end

--- a/spec/coordinate_spec.rb
+++ b/spec/coordinate_spec.rb
@@ -9,75 +9,75 @@ describe Maven::Tools::Coordinate do
   subject { A.new }
 
   it 'should convert ruby version to maven version ranges' do
-    subject.to_version.must_equal "[0,)"
-    subject.to_version('!=2.3.4').must_equal "(2.3.4,)"
-    subject.to_version('!=2.3.4.rc').must_equal "(2.3.4.rc-SNAPSHOT,)"
-    subject.to_version('=2.3.4').must_equal "[2.3.4,2.3.4.0.0.0.0.1)"
-    subject.to_version('=2.3.4.alpha').must_equal "2.3.4.alpha"
-    subject.to_version('~>1.8.2').must_equal "[1.8.2,1.8.99999]"
-    subject.to_version('~>1.8.2.beta').must_equal "[1.8.2.beta-SNAPSHOT,1.8.99999]"
-    subject.to_version('~>1.8.2.beta123.12').must_equal "[1.8.2.beta123.12-SNAPSHOT,1.8.99999]"
-    subject.to_version('~>1.8.2.1beta').must_equal "[1.8.2.1beta-SNAPSHOT,1.8.99999]"
-    subject.to_version('~>1.8').must_equal "[1.8,1.99999]"
-    subject.to_version('~>0').must_equal "[0,99999]"
-    subject.to_version('>1.2').must_equal "(1.2,)"
-    subject.to_version('>1.2.GA').must_equal "(1.2.GA-SNAPSHOT,)"
-    subject.to_version('<1.2').must_equal "[0,1.2)"
-    subject.to_version('<1.2.dev').must_equal "[0,1.2.dev-SNAPSHOT)"
-    subject.to_version('>=1.2').must_equal "[1.2,)"
-    subject.to_version('>=1.2.gamma').must_equal "[1.2.gamma-SNAPSHOT,)"
-    subject.to_version('<=1.2').must_equal "[0,1.2]"
-    subject.to_version('<=1.2.pre').must_equal "[0,1.2.pre-SNAPSHOT]"
-    subject.to_version('>=1.2', '<2.0').must_equal "[1.2,2.0)"
-    subject.to_version('>=1.2', '<=2.0').must_equal "[1.2,2.0]"
-    subject.to_version('>1.2', '<2.0').must_equal "(1.2,2.0)"
-    subject.to_version('>1.2', '<=2.0').must_equal "(1.2,2.0]"
+    _(subject.to_version).must_equal "[0,)"
+    _(subject.to_version('!=2.3.4')).must_equal "(2.3.4,)"
+    _(subject.to_version('!=2.3.4.rc')).must_equal "(2.3.4.rc-SNAPSHOT,)"
+    _(subject.to_version('=2.3.4')).must_equal "[2.3.4,2.3.4.0.0.0.0.1)"
+    _(subject.to_version('=2.3.4.alpha')).must_equal "2.3.4.alpha"
+    _(subject.to_version('~>1.8.2')).must_equal "[1.8.2,1.8.99999]"
+    _(subject.to_version('~>1.8.2.beta')).must_equal "[1.8.2.beta-SNAPSHOT,1.8.99999]"
+    _(subject.to_version('~>1.8.2.beta123.12')).must_equal "[1.8.2.beta123.12-SNAPSHOT,1.8.99999]"
+    _(subject.to_version('~>1.8.2.1beta')).must_equal "[1.8.2.1beta-SNAPSHOT,1.8.99999]"
+    _(subject.to_version('~>1.8')).must_equal "[1.8,1.99999]"
+    _(subject.to_version('~>0')).must_equal "[0,99999]"
+    _(subject.to_version('>1.2')).must_equal "(1.2,)"
+    _(subject.to_version('>1.2.GA')).must_equal "(1.2.GA-SNAPSHOT,)"
+    _(subject.to_version('<1.2')).must_equal "[0,1.2)"
+    _(subject.to_version('<1.2.dev')).must_equal "[0,1.2.dev-SNAPSHOT)"
+    _(subject.to_version('>=1.2')).must_equal "[1.2,)"
+    _(subject.to_version('>=1.2.gamma')).must_equal "[1.2.gamma-SNAPSHOT,)"
+    _(subject.to_version('<=1.2')).must_equal "[0,1.2]"
+    _(subject.to_version('<=1.2.pre')).must_equal "[0,1.2.pre-SNAPSHOT]"
+    _(subject.to_version('>=1.2', '<2.0')).must_equal "[1.2,2.0)"
+    _(subject.to_version('>=1.2', '<=2.0')).must_equal "[1.2,2.0]"
+    _(subject.to_version('>1.2', '<2.0')).must_equal "(1.2,2.0)"
+    _(subject.to_version('>1.2', '<=2.0')).must_equal "(1.2,2.0]"
   end
-  
+
   it 'should keep maven version and ranges as they are' do
-    subject.to_version('1.2.3').must_equal "1.2.3"
-    subject.to_version('(1,2)').must_equal "(1,2)"
-    subject.to_version('[1,2)').must_equal "[1,2)"
-    subject.to_version('(1,2]').must_equal "(1,2]"
-    subject.to_version('[1,2]').must_equal "[1,2]"
+    _(subject.to_version('1.2.3')).must_equal "1.2.3"
+    _(subject.to_version('(1,2)')).must_equal "(1,2)"
+    _(subject.to_version('[1,2)')).must_equal "[1,2)"
+    _(subject.to_version('(1,2]')).must_equal "(1,2]"
+    _(subject.to_version('[1,2]')).must_equal "[1,2]"
   end
 
   it 'should keep maven snapshot version and ranges as they are' do
-    subject.to_version('1.2.3-SNAPSHOT').must_equal "1.2.3-SNAPSHOT"
-    subject.to_version('(1,2-SNAPSHOT)').must_equal "(1,2-SNAPSHOT)"
-    subject.to_version('[1-SNAPSHOT,2)').must_equal "[1-SNAPSHOT,2)"
-    subject.to_version('(1,2-SNAPSHOT]').must_equal "(1,2-SNAPSHOT]"
-    subject.to_version('[1-SNAPSHOT,2]').must_equal "[1-SNAPSHOT,2]"
+    _(subject.to_version('1.2.3-SNAPSHOT')).must_equal "1.2.3-SNAPSHOT"
+    _(subject.to_version('(1,2-SNAPSHOT)')).must_equal "(1,2-SNAPSHOT)"
+    _(subject.to_version('[1-SNAPSHOT,2)')).must_equal "[1-SNAPSHOT,2)"
+    _(subject.to_version('(1,2-SNAPSHOT]')).must_equal "(1,2-SNAPSHOT]"
+    _(subject.to_version('[1-SNAPSHOT,2]')).must_equal "[1-SNAPSHOT,2]"
   end
 
   it 'should convert pom of jar deps to maven coordinate' do
-    subject.to_coordinate('something "a:b"').must_be_nil
-    subject.to_coordinate('#jar "a:b"').must_be_nil
-    subject.to_coordinate('jar "a:b" # bla').must_equal "a:b:jar:[0,)"
-    subject.to_coordinate("pom 'b:c', '!=2.3.4'").must_equal "b:c:pom:(2.3.4,)"
-    subject.to_coordinate('jar "c:d", "2.3.4"').must_equal "c:d:jar:2.3.4"
-    subject.to_coordinate("jar 'd:e', '~>1.8.2'").must_equal "d:e:jar:[1.8.2,1.8.99999]"
-    subject.to_coordinate('pom "f:g", ">1.2", "<=2.0"').must_equal "f:g:pom:(1.2,2.0]"
-    subject.to_coordinate('pom "e:f", "[1.8,1.9.9)"').must_equal "e:f:pom:[1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f", "(1.8,1.9.9)"').must_equal "e:f:pom:(1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f", "[1.8, 1.9.9]"').must_equal "e:f:pom:[1.8,1.9.9]"
+    _(subject.to_coordinate('something "a:b"')).must_be_nil
+    _(subject.to_coordinate('#jar "a:b"')).must_be_nil
+    _(subject.to_coordinate('jar "a:b" # bla')).must_equal "a:b:jar:[0,)"
+    _(subject.to_coordinate("pom 'b:c', '!=2.3.4'")).must_equal "b:c:pom:(2.3.4,)"
+    _(subject.to_coordinate('jar "c:d", "2.3.4"')).must_equal "c:d:jar:2.3.4"
+    _(subject.to_coordinate("jar 'd:e', '~>1.8.2'")).must_equal "d:e:jar:[1.8.2,1.8.99999]"
+    _(subject.to_coordinate('pom "f:g", ">1.2", "<=2.0"')).must_equal "f:g:pom:(1.2,2.0]"
+    _(subject.to_coordinate('pom "e:f", "[1.8,1.9.9)"')).must_equal "e:f:pom:[1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f", "(1.8,1.9.9)"')).must_equal "e:f:pom:(1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f", "[1.8, 1.9.9]"')).must_equal "e:f:pom:[1.8,1.9.9]"
   end
 
   it 'should support classifiers' do
-    subject.to_coordinate('something "a:b:jdk15"').must_be_nil
-    subject.to_coordinate('#jar "a:b:jdk15"').must_be_nil
-    subject.to_coordinate('jar "a:b:jdk15" # bla').must_equal "a:b:jar:jdk15:[0,)"
-    subject.to_coordinate("pom 'b:c:jdk15', '!=2.3.4'").must_equal "b:c:pom:jdk15:(2.3.4,)"
-    subject.to_coordinate('jar "c:d:jdk15", "2.3.4"').must_equal "c:d:jar:jdk15:2.3.4"
-    subject.to_coordinate("jar 'd:e:jdk15', '~>1.8.2'").must_equal "d:e:jar:jdk15:[1.8.2,1.8.99999]"
-    subject.to_coordinate('pom "f:g:jdk15", ">1.2", "<=2.0"').must_equal "f:g:pom:jdk15:(1.2,2.0]"
-    subject.to_coordinate('pom "e:f:jdk15", "[1.8,1.9.9)"').must_equal "e:f:pom:jdk15:[1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f:jdk15", "(1.8,1.9.9)"').must_equal "e:f:pom:jdk15:(1.8,1.9.9)"
-    subject.to_coordinate('pom "e:f:jdk15", "[1.8, 1.9.9]"').must_equal "e:f:pom:jdk15:[1.8,1.9.9]"
+    _(subject.to_coordinate('something "a:b:jdk15"')).must_be_nil
+    _(subject.to_coordinate('#jar "a:b:jdk15"')).must_be_nil
+    _(subject.to_coordinate('jar "a:b:jdk15" # bla')).must_equal "a:b:jar:jdk15:[0,)"
+    _(subject.to_coordinate("pom 'b:c:jdk15', '!=2.3.4'")).must_equal "b:c:pom:jdk15:(2.3.4,)"
+    _(subject.to_coordinate('jar "c:d:jdk15", "2.3.4"')).must_equal "c:d:jar:jdk15:2.3.4"
+    _(subject.to_coordinate("jar 'd:e:jdk15', '~>1.8.2'")).must_equal "d:e:jar:jdk15:[1.8.2,1.8.99999]"
+    _(subject.to_coordinate('pom "f:g:jdk15", ">1.2", "<=2.0"')).must_equal "f:g:pom:jdk15:(1.2,2.0]"
+    _(subject.to_coordinate('pom "e:f:jdk15", "[1.8,1.9.9)"')).must_equal "e:f:pom:jdk15:[1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f:jdk15", "(1.8,1.9.9)"')).must_equal "e:f:pom:jdk15:(1.8,1.9.9)"
+    _(subject.to_coordinate('pom "e:f:jdk15", "[1.8, 1.9.9]"')).must_equal "e:f:pom:jdk15:[1.8,1.9.9]"
   end
 
   it 'supports declarations with scope' do
-    subject.to_split_coordinate_with_scope('jar rubygems:ruby-maven, ~> 3.1.1.0, :scope => :provided').must_equal [:provided, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
-    subject.to_split_coordinate_with_scope("jar 'rubygems:ruby-maven', '~> 3.1.1.0', :scope => :test").must_equal [:test, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
+    _(subject.to_split_coordinate_with_scope('jar rubygems:ruby-maven, ~> 3.1.1.0, :scope => :provided')).must_equal [:provided, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
+    _(subject.to_split_coordinate_with_scope("jar 'rubygems:ruby-maven', '~> 3.1.1.0', :scope => :test")).must_equal [:test, "rubygems", "ruby-maven", "jar", "[3.1.1.0,3.1.1.99999]"]
   end
 end

--- a/spec/dsl/gemspec_spec.rb
+++ b/spec/dsl/gemspec_spec.rb
@@ -30,21 +30,21 @@ describe Maven::Tools::DSL::Gemspec do
     subject.new parent
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'maven-tools.xml', 'maven-tools'  ) )
+    _(xml).must_equal( GemspecFile.read( 'maven-tools.xml', 'maven-tools'  ) )
   end
 
   it 'evals maven_tools.gemspec from yaml' do
     subject.new parent, 'maven-tools.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( GemspecFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
   end
 
   it 'evals gemspec with jar and pom dependencies' do
     subject.new parent, 'jars_and_poms.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'jars_and_poms.xml',
+    _(xml).must_equal( GemspecFile.read( 'jars_and_poms.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -52,7 +52,7 @@ describe Maven::Tools::DSL::Gemspec do
     subject.new parent, :name => 'jars_and_poms.gemspec', :include_jars => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( GemspecFile.read( 'jars_and_poms_include_jars.xml',
+    _(xml).must_equal( GemspecFile.read( 'jars_and_poms_include_jars.xml',
                                   'gemspec_spec' ) )
   end
 end

--- a/spec/dsl/jarfile_lock_spec.rb
+++ b/spec/dsl/jarfile_lock_spec.rb
@@ -9,29 +9,29 @@ describe Maven::Tools::DSL::JarfileLock do
 
   it 'loads legacy Jarfile.lock' do
     lock = subject.new( base + '.legacy' )
-    lock.coordinates( :test ).size.must_equal 0
-    lock.coordinates.size.must_equal 52
+    _(lock.coordinates( :test ).size).must_equal 0
+    _(lock.coordinates.size).must_equal 52
   end
 
   it 'loads Jarfile.lock' do
     lock = subject.new( base )
-    lock.coordinates( :test ).size.must_equal 7
-    lock.coordinates.size.must_equal 45
+    _(lock.coordinates( :test ).size).must_equal 7
+    _(lock.coordinates.size).must_equal 45
   end
 
   it 'tests existence' do
     lock = subject.new( base )
     ( lock.coordinates( :test ) + lock.coordinates ).each do |c|
-      lock.exists?( c ).must_equal true
-      lock.exists?( c + ".bla" ).must_equal false
+      _(lock.exists?( c )).must_equal true
+      _(lock.exists?( c + ".bla" )).must_equal false
     end
   end
 
   it 'tests locked' do
     lock = subject.new( base )
     ( lock.coordinates( :test ) + lock.coordinates ).each do |c|
-      lock.locked?( c ).must_equal true
-      lock.locked?( c + ".bla" ).must_equal true
+      _(lock.locked?( c )).must_equal true
+      _(lock.locked?( c + ".bla" )).must_equal true
     end
   end
 
@@ -45,8 +45,8 @@ describe Maven::Tools::DSL::JarfileLock do
                               :runtime => [ 'huffle:puffle:321' ] } )
       lock.dump
       lock = subject.new( file )
-      lock.coordinates.must_equal ['huffle:puffle:321']
-      lock.coordinates( :test ).must_equal ['bla:blas:123']    
+      _(lock.coordinates).must_equal ['huffle:puffle:321']
+      _(lock.coordinates( :test )).must_equal ['bla:blas:123']
     ensure
       FileUtils.rm_f file_lock
     end
@@ -57,43 +57,43 @@ describe Maven::Tools::DSL::JarfileLock do
 
     lock.replace( { :test => [ 'bla:blas:123' ],
                     :runtime => [ 'huffle:puffle:321' ] } )
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
     lock.replace( { :runtime => [ 'huffle:puffle:321' ] } )
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal [] 
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal []
 
     lock.replace( { :test => [ 'bla:blas:123' ]} )
-    lock.coordinates.must_equal []
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.coordinates).must_equal []
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
   end
 
   it 'can add missing data idempotent' do
     lock = subject.new( 'something' )
 
-    lock.update_unlocked( { :test => [ 'bla:blas:123' ],
-                            :runtime => [ 'huffle:puffle:321' ] } ).must_equal true
-    lock.update_unlocked( { :test => [ 'bla:blas:123' ],
-                            :runtime => [ 'huffle:puffle:321' ] } ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:123' ],
+                            :runtime => [ 'huffle:puffle:321' ] } )).must_equal true
+    _(lock.update_unlocked( { :test => [ 'bla:blas:123' ],
+                            :runtime => [ 'huffle:puffle:321' ] } )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :runtime => [ 'huffle:puffle:321' ] } ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :runtime => [ 'huffle:puffle:321' ] } )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :runtime => [ 'huffle:puffle2:321' ] } ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :runtime => [ 'huffle:puffle2:321' ] } )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :test => [ 'bla:blas:123' ]} ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:123' ]} )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :test => [ 'bla:bla2:123' ]} ).must_equal true
-    lock.coordinates.must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123', 'bla:bla2:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:bla2:123' ]} )).must_equal true
+    _(lock.coordinates).must_equal ['huffle:puffle:321', 'huffle:puffle2:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123', 'bla:bla2:123']
   end
 
   it 'fails add data on version conflict' do
@@ -102,17 +102,17 @@ describe Maven::Tools::DSL::JarfileLock do
     lock.replace( { :test => [ 'bla:blas:123' ],
                     :runtime => [ 'huffle:puffle:321' ] } )
 
-    lock.update_unlocked( { :test => [ 'bla:blas:1233' ],
-                            :runtime => [ 'huffle:puffle:3214' ] } ).must_equal false
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:1233' ],
+                            :runtime => [ 'huffle:puffle:3214' ] } )).must_equal false
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :runtime => [ 'huffle:puffle:3214' ] } ).must_equal false
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :runtime => [ 'huffle:puffle:3214' ] } )).must_equal false
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
 
-    lock.update_unlocked( { :test => [ 'bla:blas:1233' ]} ).must_equal false
-    lock.coordinates.must_equal ['huffle:puffle:321']
-    lock.coordinates( :test ).must_equal ['bla:blas:123'] 
+    _(lock.update_unlocked( { :test => [ 'bla:blas:1233' ]} )).must_equal false
+    _(lock.coordinates).must_equal ['huffle:puffle:321']
+    _(lock.coordinates( :test )).must_equal ['bla:blas:123']
   end
 end

--- a/spec/dsl/profile_gemspec_spec.rb
+++ b/spec/dsl/profile_gemspec_spec.rb
@@ -34,7 +34,7 @@ describe Maven::Tools::DSL::ProfileGemspec do
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
     v = Maven::Tools::VERSION
     v += '-SNAPSHOT' if v =~ /.dev$/
-    xml.must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'maven-tools',
+    _(xml).must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'maven-tools',
                                   v ) )
   end
 
@@ -42,28 +42,28 @@ describe Maven::Tools::DSL::ProfileGemspec do
     subject.new parent, 'maven-tools.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'profile_gemspec_spec' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'maven-tools.xml', 'profile_gemspec_spec' ) )
   end
 
   it 'evals maven_tools.gemspec from yaml no gem dependencies' do
     subject.new parent, 'maven-tools.gemspec', :no_gems => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'no_gems.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'no_gems.xml', 'gemspec_spec' ) )
   end
 
   it 'evals snapshot.gemspec' do
     subject.new parent, 'snapshot.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
   end
 
   it 'evals gemspec with jar and pom dependencies' do
     subject.new parent, 'jars_and_poms.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'jars_and_poms.xml',
+    _(xml).must_equal( ProfileGemspecFile.read( 'jars_and_poms.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -71,7 +71,7 @@ describe Maven::Tools::DSL::ProfileGemspec do
     subject.new parent, :name => 'jars_and_poms.gemspec', :include_jars => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'jars_and_poms_include_jars.xml',
+    _(xml).must_equal( ProfileGemspecFile.read( 'jars_and_poms_include_jars.xml',
                                              'gemspec_spec' ) )
   end
 
@@ -79,6 +79,6 @@ describe Maven::Tools::DSL::ProfileGemspec do
     subject.new parent, 'unknown_license.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( ProfileGemspecFile.read( 'unknown_license.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( ProfileGemspecFile.read( 'unknown_license.xml', 'gemspec_spec' ) )
   end
 end

--- a/spec/dsl/project_gemspec_spec.rb
+++ b/spec/dsl/project_gemspec_spec.rb
@@ -34,7 +34,7 @@ describe Maven::Tools::DSL::ProjectGemspec do
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
     v = Maven::Tools::VERSION
     v += '-SNAPSHOT' if v =~ /.dev$/
-    xml.must_equal( XmlFile.read( 'maven-tools.xml', 'maven-tools',
+    _(xml).must_equal( XmlFile.read( 'maven-tools.xml', 'maven-tools',
                                   v ) )
   end
 
@@ -42,35 +42,35 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, 'maven-tools.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( XmlFile.read( 'maven-tools.xml', 'gemspec_spec' ) )
   end
 
   it 'evals maven_tools.gemspec from yaml with profile' do
     subject.new parent, 'maven-tools.gemspec', :profile => :hidden
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'profile.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( XmlFile.read( 'profile.xml', 'gemspec_spec' ) )
   end
 
   it 'evals maven_tools.gemspec from yaml no gem dependencies' do
     subject.new parent, 'maven-tools.gemspec', :no_gems => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'no_gems.xml', 'gemspec_spec' ) )
+    _(xml).must_equal( XmlFile.read( 'no_gems.xml', 'gemspec_spec' ) )
   end
 
   it 'evals snapshot.gemspec' do
     subject.new parent, 'snapshot.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
+    _(xml).must_equal( XmlFile.read( 'snapshot.xml', 'snapshot', '1.a-SNAPSHOT' ) )
   end
 
   it 'evals gemspec with jar and pom dependencies' do
     subject.new parent, 'jars_and_poms.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'jars_and_poms.xml',
+    _(xml).must_equal( XmlFile.read( 'jars_and_poms.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -78,7 +78,7 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, :name => 'jars_and_poms.gemspec', :include_jars => true
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'jars_and_poms_include_jars.xml',
+    _(xml).must_equal( XmlFile.read( 'jars_and_poms_include_jars.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -91,7 +91,7 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, :name => 'extended.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'extended.xml',
+    _(xml).must_equal( XmlFile.read( 'extended.xml',
                                   'gemspec_spec' ) )
   end
 
@@ -99,6 +99,6 @@ describe Maven::Tools::DSL::ProjectGemspec do
     subject.new parent, :name => 'unknown_license.gemspec'
     xml = ""
     Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
-    xml.must_equal( XmlFile.read( 'unknown_license.xml', 'gemspec_spec') )
+    _(xml).must_equal( XmlFile.read( 'unknown_license.xml', 'gemspec_spec') )
   end
 end

--- a/spec/gemspec_dependencies_spec.rb
+++ b/spec/gemspec_dependencies_spec.rb
@@ -25,9 +25,9 @@ describe Maven::Tools::GemspecDependencies do
   subject { Maven::Tools::GemspecDependencies.new( spec ) } 
 
   it 'should setup artifact' do
-    subject.runtime.must_equal ["rubygems:thor:[0.14.6,2.0)", "rubygems:maven-tools:[0.32.3,0.32.99999]"]
-    subject.development.must_equal ["rubygems:minitest:[5.0,5.99999]", "rubygems:rake:[10.0,10.99999]"]
-    subject.java_runtime.must_equal [ ["sdas", "das", "jar", "tes", "123"],
+    _(subject.runtime).must_equal ["rubygems:thor:[0.14.6,2.0", "rubygems:maven-tools:[0.32.3,0.32.99999]"]
+    _(subject.development).must_equal ["rubygems:minitest:[5.0,5.99999]", "rubygems:rake:[10.0,10.99999]"]
+    _(subject.java_runtime).must_equal [ ["sdas", "das", "jar", "tes", "123"],
                            ["sdas", "das", "jar", "123"],
                            ["sdas.asd", "das", "jar", "123", ["fds:fre"]],
                            ["sdas.asd", "das", "jar", "bla", "123", ["fds:fre", "ferf:de"]],
@@ -37,7 +37,7 @@ describe Maven::Tools::GemspecDependencies do
                            ["de.sdas.asd", "das", "jar", "123", ["fds:fre"]],
                            ["de.sdas.asd", "das", "jar", "bla", "123", ["fds:fre", "ferf:de"]],
                            ["de.sdas.asd", "das", "jar", "blub", "123", ["fds:fre","ferf:de"]] ]
-    subject.java_dependencies.must_equal [ [:compile, "sdas", "das", "jar", "tes", "123"],
+    _(subject.java_dependencies).must_equal [ [:compile, "sdas", "das", "jar", "tes", "123"],
                            [:compile, "sdas", "das", "jar", "123"],
                            [:compile, "sdas.asd", "das", "jar", "123", ["fds:fre"]],
                            [:compile, "sdas.asd", "das", "jar", "bla", "123", ["fds:fre", "ferf:de"]],

--- a/spec/jarfile_spec.rb
+++ b/spec/jarfile_spec.rb
@@ -38,7 +38,7 @@ describe Maven::Tools::Jarfile do
 
   it 'generates lockfile' do
     subject.generate_lockfile(%w( a b c d e f ruby.bundler:bla))
-    File.read(jfile_lock).must_equal <<-EOF
+    _(File.read(jfile_lock)).must_equal <<-EOF
 a
 b
 c
@@ -55,10 +55,10 @@ a:b:pom:3
 a:c:jar:1
 EOF
     end
-    subject.locked.must_equal ["a:b:pom:3", "a:c:jar:1"]
-    subject.locked?("a:b:pom:321").must_equal true
-    subject.locked?("a:b:jar:321").must_equal true
-    subject.locked?("a:d:jar:432").must_equal false
+    _(subject.locked).must_equal ["a:b:pom:3", "a:c:jar:1"]
+    _(subject.locked?("a:b:pom:321")).must_equal true
+    _(subject.locked?("a:b:jar:321")).must_equal true
+    _(subject.locked?("a:d:jar:432")).must_equal false
   end
 
   it 'populate repositories' do
@@ -70,11 +70,11 @@ source "http://example.org/repo/3"
 EOF
     end
     subject.populate_unlocked container
-    container.repositories.size.must_equal 3
-    container.artifacts.size.must_equal 0
-    container.repositories[0].must_equal "first"
-    container.repositories[1].must_equal "second"
-    container.repositories[2].must_equal "http://example.org/repo/3"
+    _(container.repositories.size).must_equal 3
+    _(container.artifacts.size).must_equal 0
+    _(container.repositories[0]).must_equal "first"
+    _(container.repositories[1]).must_equal "second"
+    _(container.repositories[2]).must_equal "http://example.org/repo/3"
   end
 
   it 'populate artifacts without locked' do
@@ -85,10 +85,10 @@ pom 'x:y', '987'
 EOF
     end
     subject.populate_unlocked container
-    container.repositories.size.must_equal 0
-    container.artifacts.size.must_equal 2
-    container.artifacts[0].to_s.must_equal "a:b:jar:123"
-    container.artifacts[1].to_s.must_equal "x:y:pom:987"
+    _(container.repositories.size).must_equal 0
+    _(container.artifacts.size).must_equal 2
+    _(container.artifacts[0].to_s).must_equal "a:b:jar:123"
+    _(container.artifacts[1].to_s).must_equal "x:y:pom:987"
   end
 
   it 'populate artifacts with locked' do
@@ -105,9 +105,9 @@ EOF
     end
     
     subject.populate_unlocked container
-    container.repositories.size.must_equal 0
-    container.artifacts.size.must_equal 1
-    container.artifacts[0].to_s.must_equal "x:y:pom:987"
+    _(container.repositories.size).must_equal 0
+    _(container.artifacts.size).must_equal 1
+    _(container.artifacts[0].to_s).must_equal "x:y:pom:987"
   end
 
   it 'populate locked artifacts' do
@@ -118,8 +118,8 @@ EOF
     end
     
     subject.populate_locked container
-    container.repositories.size.must_equal 0
-    container.artifacts.size.must_equal 1
-    container.artifacts[0].to_s.must_equal "a:b:jar:432"
+    _(container.repositories.size).must_equal 0
+    _(container.artifacts.size).must_equal 1
+    _(container.artifacts[0].to_s).must_equal "a:b:jar:432"
   end
 end

--- a/spec/pom_spec.rb
+++ b/spec/pom_spec.rb
@@ -18,7 +18,7 @@ describe Maven::Tools::POM do
         pom_xml.gsub!( /tesla-polyglot/, 'polyglot' )
         pom_xml.gsub!( /${tesla.version}/, Maven::Tools::VERSIONS[ :polyglot_version ] )
 
-        pom.to_s.must_equal pom_xml
+        _(pom.to_s).must_equal pom_xml
       end
     end
   end


### PR DESCRIPTION
Hi, while attempting to upgrade Nexus Repository Manager 2 to a newer version of JRuby I ran into some issues caused by axiom-types (a dependency of virtus) it appears it does not work on newer versions of Ruby. It appears that that library has been abandoned by its authors (a PR fixing it was opened 5-years ago).

I'll lead with - I'm not a ruby programmer, I've never touched it before but I've made an attempt here to switch from the also deprecated virtus to its successor dry-struct. AFAICT in the context of Nexus my changes work.

However dry-struct inserts fields into a Hash thus doesn't maintain order and results in POMs whose elements are in an arbitrary order. With my limited knowledge of ruby I wasn't able to figure out a way to iterate over the fields in the defined order, though I suspect its possible.

The obvious issue here is that this leads to test failures, I have other changes which attempt to resolve that by making the expected test results match the arbitrary ordering though I wasn't able to resolve all the issues (the expected output is used for multiple tests which generate different arbitrary ordering)