### PR TITLE
Remove all references to torquebox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 maven tools 
 ===========
 
-* [![Build Status](https://github.com/torquebox/maven-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/torquebox/maven-tools/actions/workflows/ci.yml)
-* [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/torquebox/maven-tools)
+* [![Build Status](https://github.com/jruby/maven-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/jruby/maven-tools/actions/workflows/ci.yml)
 
 Note on Ruby-1.8
 ----------------

--- a/lib/maven/tools/dsl.rb
+++ b/lib/maven/tools/dsl.rb
@@ -18,16 +18,6 @@ module Maven
         @model.version = '0.0.0'
         @context = :project
         nested_block( :project, @model, block ) if block
-        if @needs_torquebox
-          if ! @model.repositories.detect { |r| r.id == 'rubygems-prereleases' }  && @model.dependencies.detect { |d| d.group_id == 'rubygems' && d.version.match( /-SNAPSHOT/ ) }
-            
-            @current = @model
-            snapshot_repository(  'rubygems-prereleases',
-                                  'http://rubygems-proxy.torquebox.org/prereleases' )
-            @current = nil
-          end
-          @needs_torquebox = nil
-        end
         result = @model
         @context = nil
         @model = nil
@@ -55,7 +45,6 @@ module Maven
 
       # TODO remove me
       def needs_torquebox= t
-        @needs_torquebox = t
       end
       # TODO remove me
       def current
@@ -280,7 +269,6 @@ module Maven
             
             repository( 'mavengems', 'mavengem:https://rubygems.org' )
           end
-          @needs_torquebox = true
 
           setup_jruby_plugins_version
         end

--- a/lib/maven/tools/dsl/gem_support.rb
+++ b/lib/maven/tools/dsl/gem_support.rb
@@ -47,7 +47,6 @@ module Maven
             @parent.repository( 'mavengems',
                                 'mavengem:https://rubygems.org' )
           end
-          @parent.needs_torquebox = true
             
           setup_jruby_plugins_version( project )
           

--- a/lib/maven/tools/version.rb
+++ b/lib/maven/tools/version.rb
@@ -20,6 +20,6 @@
 #
 module Maven
   module Tools
-    VERSION = '1.2.2'.freeze
+    VERSION = '1.2.3'.freeze
   end
 end

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <version>1.2.2</version>
   <packaging>gem</packaging>
   <name>helpers for maven related tasks</name>
-  <url>http://github.com/torquebox/maven-tools</url>
+  <url>http://github.com/jruby/maven-tools</url>
   <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
   <developers>
     <developer>
@@ -14,8 +14,8 @@
     </developer>
   </developers>
   <scm>
-    <connection>https://github.com/torquebox/maven-tools.git</connection>
-    <url>http://github.com/torquebox/maven-tools</url>
+    <connection>https://github.com/jruby/maven-tools.git</connection>
+    <url>http://github.com/jruby/maven-tools</url>
   </scm>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
This would remove the none-existing torquebox repo which is used only for 'snapshots' or 'prereleases'. As this piece of code will produce errors (torquebox repo does not exist anymore) it is fair to remove it altogether as bugfix release.